### PR TITLE
Update newsletter URL

### DIFF
--- a/rsrc_channels.qmd
+++ b/rsrc_channels.qmd
@@ -20,7 +20,7 @@ library(tibble)
 library(kableExtra)
 tribble(~Channel, ~Purpose,
         "Website <https://ropensci.org/> <https://github.com/ropensci/roweb3>", "Home of rOpenSci",
-        "[Newsletter](https://news.ropensci.org/)", "A digest of R package news, use cases, blog posts, events, curated every two weeks. [Subscribe](https://news.ropensci.org/) via RSS (XML), JSON feed, or email.",
+        "[Newsletter](https://ropensci.org/news/)", "A digest of R package news, use cases, blog posts, events, curated every two weeks. [Subscribe](https://ropensci.org/news/) via RSS (XML), JSON feed, or email.",
         "[Videos](https://vimeo.com/ropensci)", "Videos from past Community Calls on Vimeo",
         "[Mastodon](https://hachyderm.io/@rOpenSci)", "Posts about rOpenSci software, use cases, blog posts, tech notes, events",
         "Video conferencing", "Community Calls and remote co-working sessions on Zoom",

--- a/rsrc_channels.qmd
+++ b/rsrc_channels.qmd
@@ -119,7 +119,7 @@ and an rOpenSci Community Call - [How to Ask Questions so they get Answered! Pos
 
 *   Read our [Code of Conduct](https://ropensci.org/code-of-conduct/) to ensure you are ready to participate
 *   **Follow [rOpenSci on Mastodon](https://hachyderm.io/@rOpenSci)**
-*   **Subscribe to our [Newsletter](https://news.ropensci.org/)**
+*   **Subscribe to our [Newsletter](https://ropensci.org/news/)**
 *   **Ask or answer questions**. Participate in discussions in the [forum](https://discuss.ropensci.org/), on GitHub or on Slack
 *   **Try a 2-hour [remote co-working session](https://www.cscce.org/2020/02/04/online-co-working-partnerships-are-community-of-practice-in-action/)** with someone in our Slack #co-working channel
 *   **Seek community feedback on your package ideas in the "Packages" category in our [forum](https://discuss.ropensci.org/c/packages)**

--- a/rsrc_devguide.qmd
+++ b/rsrc_devguide.qmd
@@ -87,5 +87,5 @@ and in the core curriculum of a Master of Data Science program: [Using rOpenSci 
 *   Add a CITATION file to **ensure your package is easily citable**
 *   **Request a co-maintainer for your package**. Post a request in the  #package-maintenance [Slack channel](#channels-Slack).
 *   **Volunteer to maintain a package**. 
-    Check out the [rOpenSci Newsletter](https://news.ropensci.org/), 
+    Check out the [rOpenSci Newsletter](https://ropensci.org/news/), 
     the last section is a "Call For Maintainers" and consists of a list of packages specifically looking for maintainers.


### PR DESCRIPTION
I found that the URL that's currently here sends me to the archives from pre-2022